### PR TITLE
Add some Unit Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A parser that converts SJSON into JSON",
   "license": "Apache-2.0",
   "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Autodesk/sjson.git"
@@ -19,5 +22,9 @@
   "homepage": "https://github.com/Autodesk/sjson#readme",
   "engines": {
     "node": ">=4"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.1.2"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--check-leaks
+--recursive
+--inline-diffs

--- a/test/sample.json
+++ b/test/sample.json
@@ -1,0 +1,37 @@
+{
+  "name": "Sample",
+  "description": "A sample json document.",
+  "version": "0.0.1",
+  "author": {
+    "name": "Autodesk"
+  },
+  "keywords": [
+    "sample",
+    "sjson"
+  ],
+  "object": {
+    "arr": [
+      {
+        "str": "String Value",
+        "object": {
+          "type": "lua",
+          "script": "\r\n\t\t\t\t\trequire \"some/resource\"\r\n\t\t\t\t\tlocal result = Sample:generate()\r\n\t\t\t\t\tprint(\"Multiline String Sample\", result)\r\n\t\t\t\t"
+        },
+        "otherStr": "Another String"
+      }
+    ],
+    "arr2": [
+      {
+        "str": "String Value"
+      }
+    ]
+  },
+  "platforms": [
+    "win64",
+    "win32",
+    "linux"
+  ],
+  "dependencies": {
+    "sjson": "^1.0"
+  }
+}

--- a/test/sample.sjson
+++ b/test/sample.sjson
@@ -1,0 +1,41 @@
+// About
+//
+name = "Sample"
+description = "A sample json document."
+version = "0.0.1"
+author = {
+	name = "Autodesk"
+}
+keywords = ["sample", "sjson"]
+
+// SJSON Object
+//
+object = {
+	arr = [
+		{
+			str = "String Value"
+			object = {
+				type = "lua"
+				script = """
+					require "some/resource"
+					local result = Sample:generate()
+					print("Multiline String Sample", result)
+				"""
+			}
+			otherStr = "Another String"
+		}
+	]
+
+	arr2 = [
+		{
+			str = "String Value"
+		}
+	]
+}
+
+// Array
+//
+platforms = ["win64", "win32", "linux"]
+dependencies = {
+	"sjson" = "^1.0"
+}

--- a/test/sjson.spec.js
+++ b/test/sjson.spec.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const expect = require('chai').expect;
+const sjsonParse = require('./../index.js');
+
+
+/**
+ * Parse the "sample.json" file as a JavaScript Object.
+ *
+ * @return {Object} The parsed content of the "sample.json" file.
+ */
+function getJSONSample() {
+  const jsonSampleFilePath = path.join(__dirname, 'sample.json');
+  const jsonSample = require(jsonSampleFilePath);
+  return jsonSample;
+}
+
+/**
+ * Parse the "sample.sjson" file using the SJSON Parser.
+ *
+ * @return {Promise} A Promise to be fulfilled once the content of the
+ *                   "sample.sjson" file has been parsed.
+ */
+function getSJSONSample() {
+  const sjsonSampleFilePath = path.join(__dirname, 'sample.sjson');
+
+  return new Promise((resolve, reject) => {
+    fs.readFile(sjsonSampleFilePath, 'utf-8', (error, data) => {
+      if (error) {
+        reject(error);
+      } else {
+        const parsedSJSON = sjsonParse(data);
+        resolve(parsedSJSON);
+      }
+    });
+  });
+}
+
+
+describe('simplified-json', function () {
+  describe('#parse()', function () {
+
+    /**
+     * Validate that the value returned by the SJSON Parser is a JavaScript
+     * Object.
+     */
+    it('returns a JavaScript Object', function () {
+      return getSJSONSample()
+        .then(parsedSJSON => {
+          expect(parsedSJSON).to.be.an('object');
+        });
+    });
+
+    /**
+     * Validate that the value returned by SJSON Parser is an extensible
+     * JavaScript Object (i.e. that it can have new properties added to it).
+     */
+    it('returns an extensible JavaScript Object', function () {
+      return getSJSONSample()
+        .then(parsedSJSON => {
+          expect(parsedSJSON).to.be.extensible;
+          expect(parsedSJSON).to.not.be.sealed;
+          expect(parsedSJSON).to.not.be.frozen;
+        });
+    });
+
+    /**
+     * Compare the SJSON sample file to its expected JSON representation.
+     */
+    it('parses SJSON into JSON', function () {
+      return getSJSONSample()
+        .then(parsedSJSON => {
+          const expectedJSON = getJSONSample();
+
+          expect(expectedJSON).to.eql(parsedSJSON);
+        });
+    });
+
+    /**
+     * Validate that the SJSON Parser correctly parses Numbers.
+     */
+    it('parses Numbers', function () {
+      const parsedSJSON = sjsonParse('integer = 42, float = 42.4');
+
+      expect(parsedSJSON.integer).to.be.a('Number');
+      expect(parsedSJSON.integer).to.eql(42);
+      expect(parsedSJSON.float).to.be.a('Number');
+      expect(parsedSJSON.float).to.eql(42.4);
+    });
+
+    /**
+     * Validate that the SJSON Parser correctly parses Strings.
+     */
+    it('parses Strings', function () {
+      const parsedSJSON = sjsonParse('string = "sjson"');
+
+      expect(parsedSJSON.string).to.be.a('String');
+      expect(parsedSJSON.string).to.eql('sjson');
+    });
+
+    /**
+     * Validate that the SJSON Parser correctly parses Arrays.
+     */
+    it('parses Arrays', function () {
+      const parsedSJSON = sjsonParse('array = [42, "sjson"]');
+
+      expect(parsedSJSON.array).to.be.an('Array');
+      expect(parsedSJSON.array[0]).to.eql(42);
+      expect(parsedSJSON.array[1]).to.eql('sjson');
+    });
+
+    /**
+     * Validate that the SJSON Parser correctly parses Booleans.
+     */
+    it('parses Booleans', function () {
+      const parsedSJSON = sjsonParse('boolean_true = true, boolean_false = false');
+
+      expect(parsedSJSON.boolean_true).to.be.a('Boolean');
+      expect(parsedSJSON.boolean_true).to.be.true;
+      expect(parsedSJSON.boolean_false).to.be.a('Boolean');
+      expect(parsedSJSON.boolean_false).to.be.false;
+    });
+
+    /**
+     * Validate that the SJSON Parser correctly parses Nulls.
+     */
+    it('parses Nulls', function () {
+      const parsedSJSON = sjsonParse('nullable = null');
+
+      expect(parsedSJSON.nullable).to.be.a('null');
+      expect(parsedSJSON.nullable).to.be.null;
+    });
+
+    /**
+     * Validate that the SJSON Parser throws a SyntaxError when encountering an
+     * unexpected token.
+     */
+    it('throws an error when the syntax is incorrect', function () {
+      const incorrectFile = 'variable = syntax_error';
+      const testRunner = () => sjsonParse(incorrectFile);
+
+      expect(testRunner).to.throw(SyntaxError, /Unexpected token/);
+    });
+  });
+});


### PR DESCRIPTION
### Description

This PR adds some Unit Tests to validate the behavior of the SJSON Parser.

This should make it easier to maintain the library over time without introducing regressions, as well as gain the trust of developers by ensuring it behaves according to the specs.

Used the examples listed in the [README.md](https://github.com/Autodesk/sjson/blob/a999babd54bc2d3e4a9f1107cdd61adcda179bb0/README.md#usage) as a source for tests. Added a few more to validate other features such as Exception handling.

### Running Unit Tests

To execute tests, make sure to install `devDependencies` first, then run Mocha tests:
```bash
npm install
npm run test
```
![image](https://cloud.githubusercontent.com/assets/7603502/20028306/42e0f750-a304-11e6-8fb5-17d1ee3351f4.png)

### Additional Notes 

Even these few tests are sufficient to get ~78% Statement Coverage (when run through `nyc`). Adding a few more specialized tests could bring this number even higher.

![image](https://cloud.githubusercontent.com/assets/7603502/20027909/5a308ab2-a2f8-11e6-8247-1bfd41928263.png)