### PR TITLE
Integrate Unit Tests to Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - "4"
   - "5"
   - "6"
-  
+script:
+  - npm test


### PR DESCRIPTION
Integrate Unit Tests to Travis CI, causing Builds to fail if any test does not succeed.

This PR leverages the Travis CI integration to mark builds a failed if any of the Unit Tests introduced by https://github.com/Autodesk/sjson/pull/2 do not pass.

### Validation

Validated that builds completing without any errors are marked as `passed` in Travis:

**Reference:** https://travis-ci.org/philsawicki/sjson/jobs/174095466

_Build overview:_
![image](https://cloud.githubusercontent.com/assets/7603502/20084700/140386c0-a532-11e6-965b-80747258306a.png)

_Unit Test details:_
![image](https://cloud.githubusercontent.com/assets/7603502/20084624/a278652a-a531-11e6-828e-af9f66a3b53c.png)

Also validated that builds completing with errors are marked as `failed` in Travis, by updating _index.js_ to purposefully fail one of the Unit Tests):

**Reference:** https://travis-ci.org/philsawicki/sjson/builds/174090690

_Build overview:_
![image](https://cloud.githubusercontent.com/assets/7603502/20084524/e47cf6e4-a530-11e6-9c82-c66949f5d62a.png)

_Unit Test details:_
![image](https://cloud.githubusercontent.com/assets/7603502/20084666/e50cf194-a531-11e6-8737-0daed3135b04.png)

