### PR TITLE
Add proper escaping according to the JSON spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -211,10 +211,10 @@ class SJSON {
       let v = '\n';
       let i = 0;
       for(i; i < nbTabs; i++) {
-        v += '\t'
+        v += '\t';
       }
       return v;
-    }
+    };
 
     function sstring(s) {
       if(s.match(/\r|\n/)) {

--- a/index.js
+++ b/index.js
@@ -217,10 +217,44 @@ class SJSON {
     };
 
     function sstring(s) {
-      if(s.match(/\r|\n/)) {
+      if (s.match(/\r|\n/)) {
         return '"""' + s + '"""';
       }
-      return '"' + s.replace(/"/g, '\\"') + '"';
+      else {
+        let r = "";
+        for (const symbol of s) {
+          switch (symbol) {
+            case '"':
+              r += '\\"';
+              break;
+            case '\\':
+              r += '\\\\';
+              break;
+            case '/':
+              r += '\/';
+              break;
+            case '\b':
+              r += '\\b';
+              break;
+            case '\f':
+              r += '\\f';
+              break;
+            case '\n':
+              r += '\\n';
+              break;
+            case '\r':
+              r += '\\r';
+              break;
+            case '\t':
+              r += '\\t';
+              break;
+            default:
+              r += symbol;
+              break;
+          }
+        }
+        return '"' + r + '"';
+      }
     }
 
     function snumber(n) {

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class SJSON {
       for (; s[i] !== 34; ++i) { // unescaped "
         if (s[i] === 92) {
           ++i;
-          if (s[i] == 98) octets.push(7); // \b
+          if (s[i] == 98) octets.push(8); // \b
           else if (s[i] == 102) octets.push(12); // \f
           else if (s[i] == 110) octets.push(10); // \n
           else if (s[i] == 114) octets.push(13); // \r

--- a/test/sjson.spec.js
+++ b/test/sjson.spec.js
@@ -175,6 +175,13 @@ describe('simplified-json', function () {
       expect(result).to.equal(expectedResult);
     });
 
+    it('should stringify a single-line string with proper escaping according to the JSON spec', function() {
+      const input = "\u03B8\b\t\\\"//\\//ñëiø☃\\\\\fâônàæ";
+      const expectedResult = JSON.stringify(input);
+      const result = SJSON.stringify(input);
+      expect(result).to.equal(expectedResult);
+    });
+
     /**
      * Validate that the SJSON stringify number(s)
      */


### PR DESCRIPTION
* Fixes the backspace char code in `SJSON.parse`
* Adds proper escaping to `SJSON.stringify` for single-line strings
* Ignores `node_modules`